### PR TITLE
fix(category): use image_url column for article images on category page

### DIFF
--- a/app/helpers/category_helper.rb
+++ b/app/helpers/category_helper.rb
@@ -14,7 +14,13 @@ module CategoryHelper
         @cat_article = article
         content_tag :article do
           concat(content_tag(:figure) do
-            article.image.exists? ? concat(image_tag(article.image.url)) : concat(image_tag('https://source.unsplash.com/random/?happy'))
+            if article.image_url.present?
+              concat(image_tag(article.image_url))
+            elsif article.image.exists?
+              concat(image_tag(article.image.url))
+            else
+              concat(image_tag('https://picsum.photos/seed/default/800/600'))
+            end
           end)
           concat(content_tag(:div, class: 'article-content') do
             concat(content_tag(:div) do


### PR DESCRIPTION


## Description

The category page was still using the old Unsplash fallback URL (`source.unsplash.com/random/?happy`) for article images instead of the `image_url` column from the database. The home page had already been updated to use `image_url` first, but the category helper was missed.

## Before

```ruby
article.image.exists? ? concat(image_tag(article.image.url)) : concat(image_tag('https://source.unsplash.com/random/?happy'))
```

## After

```ruby
if article.image_url.present?
  concat(image_tag(article.image_url))
elsif article.image.exists?
  concat(image_tag(article.image.url))
else
  concat(image_tag('https://picsum.photos/seed/default/800/600'))
end
```

## Verification

- Ad-hoc Ruby script confirmed all three branches (image_url, Paperclip, default) route to correct URLs.
- Logic matches the identical pattern already working on the home page (`HomeHelper#article_images`).

## Changes

- `app/helpers/category_helper.rb` — 7 insertions, 1 deletion
